### PR TITLE
[FEATURE] impelemented so redis4net can use clusterconnectionstrings

### DIFF
--- a/src/redis4net/Appender/RedisAppender.cs
+++ b/src/redis4net/Appender/RedisAppender.cs
@@ -11,7 +11,7 @@ namespace redis4net.Appender
 		protected ConnectionFactory ConnectionFactory { get; set; }
 		public string RemoteAddress { get; set; }
 		public int RemotePort { get; set; }
-        public string ClusterConnectionString { get; set; }
+        public string ConnectionString { get; set; }
 		public string ListName { get; set; }
 
 		public override void ActivateOptions()
@@ -25,7 +25,7 @@ namespace redis4net.Appender
 		{
 		    var connection = new Connection();
 
-		    ConnectionFactory = string.IsNullOrEmpty(ClusterConnectionString) ? new ConnectionFactory(connection,ClusterConnectionString,1,ListName) : new ConnectionFactory(connection, RemoteAddress, RemotePort, 1, ListName);
+		    ConnectionFactory = string.IsNullOrEmpty(ConnectionString) ? new ConnectionFactory(connection,ConnectionString,1,ListName) : new ConnectionFactory(connection, RemoteAddress, RemotePort, 1, ListName);
 		}
 
 	    protected override void Append(log4net.Core.LoggingEvent loggingEvent)

--- a/src/redis4net/Appender/RedisAppender.cs
+++ b/src/redis4net/Appender/RedisAppender.cs
@@ -11,6 +11,7 @@ namespace redis4net.Appender
 		protected ConnectionFactory ConnectionFactory { get; set; }
 		public string RemoteAddress { get; set; }
 		public int RemotePort { get; set; }
+        public string ClusterConnectionString { get; set; }
 		public string ListName { get; set; }
 
 		public override void ActivateOptions()
@@ -22,11 +23,12 @@ namespace redis4net.Appender
 
 		protected virtual void InitializeConnectionFactory()
 		{
-			var connection = new Connection();
-			ConnectionFactory = new ConnectionFactory(connection, RemoteAddress, RemotePort, 1, ListName);
+		    var connection = new Connection();
+
+		    ConnectionFactory = string.IsNullOrEmpty(ClusterConnectionString) ? new ConnectionFactory(connection,ClusterConnectionString,1,ListName) : new ConnectionFactory(connection, RemoteAddress, RemotePort, 1, ListName);
 		}
 
-		protected override void Append(log4net.Core.LoggingEvent loggingEvent)
+	    protected override void Append(log4net.Core.LoggingEvent loggingEvent)
 		{
 			try
 			{

--- a/src/redis4net/Redis/Connection.cs
+++ b/src/redis4net/Redis/Connection.cs
@@ -10,7 +10,20 @@ namespace redis4net.Redis
 		private string _listName;
 		private ConnectionMultiplexer redis;
 
-		public void Open(string hostname, int port, string listName)
+	    public void OpenCluster(string clusterConnectionString, string listName)
+	    {
+            try
+            {
+                _listName = listName;
+                redis = ConnectionMultiplexer.Connect(clusterConnectionString);
+            }
+            catch
+            {
+                redis = null;
+            }
+        }
+
+	    public void Open(string hostname, int port, string listName)
 		{
 			try
 			{

--- a/src/redis4net/Redis/Connection.cs
+++ b/src/redis4net/Redis/Connection.cs
@@ -10,12 +10,12 @@ namespace redis4net.Redis
 		private string _listName;
 		private ConnectionMultiplexer redis;
 
-	    public void OpenCluster(string clusterConnectionString, string listName)
+	    public void OpenWithConnectionString(string connectionString, string listName)
 	    {
             try
             {
                 _listName = listName;
-                redis = ConnectionMultiplexer.Connect(clusterConnectionString);
+                redis = ConnectionMultiplexer.Connect(connectionString);
             }
             catch
             {

--- a/src/redis4net/Redis/IConnection.cs
+++ b/src/redis4net/Redis/IConnection.cs
@@ -4,6 +4,7 @@ namespace redis4net.Redis
 {
 	public interface IConnection
 	{
+	    void OpenCluster(string clusterConnectionString, string listName);
 		void Open(string hostname, int port, string listName);
 		bool IsOpen();
 		Task<long> AddToList(string content);

--- a/src/redis4net/Redis/IConnection.cs
+++ b/src/redis4net/Redis/IConnection.cs
@@ -4,7 +4,7 @@ namespace redis4net.Redis
 {
 	public interface IConnection
 	{
-	    void OpenCluster(string clusterConnectionString, string listName);
+	    void OpenWithConnectionString(string connectionString, string listName);
 		void Open(string hostname, int port, string listName);
 		bool IsOpen();
 		Task<long> AddToList(string content);

--- a/src/redis4net/Redis/IConnectionFactory.cs
+++ b/src/redis4net/Redis/IConnectionFactory.cs
@@ -13,6 +13,16 @@ namespace redis4net.Redis
 		private readonly int _failedConnectionRetryTimeoutInSeconds;
 		private readonly string _listName;
 		private readonly IConnection _connection;
+	    private string _clusterConnectionString;
+	    private bool _usingCluster = false;
+
+	    public ConnectionFactory(IConnection connection, string clusterConnectionString, int failedConnectionRetryTimeoutInSeconds, string listName)
+	    {
+	        _clusterConnectionString = clusterConnectionString;
+            _failedConnectionRetryTimeoutInSeconds = failedConnectionRetryTimeoutInSeconds;
+            _listName = listName;
+	        _usingCluster = true;
+	    }
 
 		public ConnectionFactory(IConnection connection, string hostName, int portNumber, int failedConnectionRetryTimeoutInSeconds, string listName)
 		{
@@ -60,7 +70,15 @@ namespace redis4net.Redis
 		{
 			if (!_connection.IsOpen())
 			{
-				_connection.Open(_hostname, _portNumber, _listName);
+			    if (_usingCluster)
+			    {
+			        _connection.OpenCluster(_clusterConnectionString,_listName);
+			    }
+			    else
+			    {
+                    _connection.Open(_hostname, _portNumber, _listName);
+                }
+				
 			}
 		}
 	}

--- a/src/redis4net/Redis/IConnectionFactory.cs
+++ b/src/redis4net/Redis/IConnectionFactory.cs
@@ -13,15 +13,15 @@ namespace redis4net.Redis
 		private readonly int _failedConnectionRetryTimeoutInSeconds;
 		private readonly string _listName;
 		private readonly IConnection _connection;
-	    private string _clusterConnectionString;
-	    private bool _usingCluster = false;
+	    private string _connectionString;
+	    private readonly bool _usingConnectionString = false;
 
-	    public ConnectionFactory(IConnection connection, string clusterConnectionString, int failedConnectionRetryTimeoutInSeconds, string listName)
+	    public ConnectionFactory(IConnection connection, string connectionString, int failedConnectionRetryTimeoutInSeconds, string listName)
 	    {
-	        _clusterConnectionString = clusterConnectionString;
+	        _connectionString = connectionString;
             _failedConnectionRetryTimeoutInSeconds = failedConnectionRetryTimeoutInSeconds;
             _listName = listName;
-	        _usingCluster = true;
+	        _usingConnectionString = true;
 	    }
 
 		public ConnectionFactory(IConnection connection, string hostName, int portNumber, int failedConnectionRetryTimeoutInSeconds, string listName)
@@ -70,9 +70,9 @@ namespace redis4net.Redis
 		{
 			if (!_connection.IsOpen())
 			{
-			    if (_usingCluster)
+			    if (_usingConnectionString)
 			    {
-			        _connection.OpenCluster(_clusterConnectionString,_listName);
+			        _connection.OpenWithConnectionString(_connectionString,_listName);
 			    }
 			    else
 			    {

--- a/src/redis4net/packages.config
+++ b/src/redis4net/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
-  <package id="StackExchange.Redis" version="1.0.414" targetFramework="net452" />
+  <package id="log4net" version="2.0.5" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net452" />
+  <package id="StackExchange.Redis" version="1.0.488" targetFramework="net452" />
 </packages>

--- a/src/redis4net/redis4net.nuspec
+++ b/src/redis4net/redis4net.nuspec
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>redis4net.ezy</id>
+    <version>1.0.0.0</version>
+    <title>redis4net (ezy edition)</title>
+    <authors>ezy</authors>
+    <owners>redis4net</owners>
+    <projectUrl>https://github.com/govin/redis4net</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>redis4net - log4net redis appender</description>
+    <copyright>Copyright ©  2014</copyright>
+    <dependencies>
+      <dependency id="log4net" version="2.0.3" />
+      <dependency id="Newtonsoft.Json" version="4.5.10" />
+      <dependency id="StackExchange.Redis" version="1.0.297" />
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
This is a very fast implementation of cluster support. 

Cause stackexhange support redis cluster.

https://github.com/StackExchange/StackExchange.Redis/blob/master/Docs/Basics.md

```
ConnectionMultiplexer redis = ConnectionMultiplexer.Connect("server1:6379,server2:6379");
```

This commit should make it possible to use. But maybe you want to clean it up or so. :+1: 
